### PR TITLE
Support Switchy 1.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = true
 
 # Mod Properties
-version = 1.0.0
+version = 1.0.1
 maven_group = xyz.fulmine
 archives_base_name = switchy-teleport
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ minecraft = "1.19.2"
 quilt_mappings = "1.19.2+build.19"
 quilt_loader = "0.17.4"
 
-switchy = "1.4.1+1.19"
+switchy = "1.8.0+1.19"
 
 quilted_fabric_api = "4.0.0-beta.14+0.62.0-1.19.2"
 

--- a/src/main/java/xyz/fulmine/switchy_teleport/compat/LastLocationCompat.java
+++ b/src/main/java/xyz/fulmine/switchy_teleport/compat/LastLocationCompat.java
@@ -1,32 +1,30 @@
 package xyz.fulmine.switchy_teleport.compat;
 
+import folk.sisby.switchy.api.ModuleImportable;
 import folk.sisby.switchy.api.PresetModule;
 import folk.sisby.switchy.api.PresetModuleRegistry;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.util.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 import xyz.fulmine.switchy_teleport.Location;
 import xyz.fulmine.switchy_teleport.SwitchyTeleport;
 import xyz.fulmine.switchy_teleport.utils.TeleportUtils;
 
+import java.util.Set;
+
 public class LastLocationCompat implements PresetModule {
 	final static Identifier ID = new Identifier(SwitchyTeleport.ID, "last_location");
-	final static boolean isDefault = false;
 
 	final static String KEY_LAST_LOCATION = "last_location";
 
 	@Nullable private Location lastLocation = null;
 
 	@Override
-	public void updateFromPlayer(PlayerEntity player) {
+	public void updateFromPlayer(PlayerEntity player, @Nullable String nextPreset) {
 		ServerPlayerEntity serverPlayer = ((ServerPlayerEntity)player);
 
 		this.lastLocation = new Location(
@@ -82,26 +80,11 @@ public class LastLocationCompat implements PresetModule {
 		}
 	}
 
-	@Override
-	public Identifier getId() {
-		return ID;
-	}
-
-	@Override
-	public MutableText getDisableConfirmation() {
-		return Text.translatable("commands.switchy_teleport.module.warn.location");
-	}
-
-	@Override
-	public boolean isDefault() {
-		return isDefault;
-	}
-
 	public static void touch() {
 	}
 
 	// Runs on touch() - but only once.
 	static {
-		PresetModuleRegistry.registerModule(ID, LastLocationCompat::new);
+		PresetModuleRegistry.registerModule(ID, LastLocationCompat::new, false, ModuleImportable.OPERATOR, Set.of(), Text.translatable("commands.switchy_teleport.module.warn.location"));
 	}
 }

--- a/src/main/java/xyz/fulmine/switchy_teleport/compat/SpawnPointCompat.java
+++ b/src/main/java/xyz/fulmine/switchy_teleport/compat/SpawnPointCompat.java
@@ -1,12 +1,12 @@
 package xyz.fulmine.switchy_teleport.compat;
 
+import folk.sisby.switchy.api.ModuleImportable;
 import folk.sisby.switchy.api.PresetModule;
 import folk.sisby.switchy.api.PresetModuleRegistry;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
@@ -16,16 +16,17 @@ import org.jetbrains.annotations.Nullable;
 import xyz.fulmine.switchy_teleport.Location;
 import xyz.fulmine.switchy_teleport.SwitchyTeleport;
 
+import java.util.Set;
+
 public class SpawnPointCompat implements PresetModule {
 	final static Identifier ID = new Identifier(SwitchyTeleport.ID, "spawn_point");
-	final static boolean isDefault = false;
 
 	final static String KEY_RESPAWN_POINT = "respawn_point";
 
 	@Nullable private Location respawnLocation = null;
 
 	@Override
-	public void updateFromPlayer(PlayerEntity player) {
+	public void updateFromPlayer(PlayerEntity player, @Nullable String nextPreset) {
 		ServerPlayerEntity serverPlayer = ((ServerPlayerEntity)player);
 		BlockPos respawnPoint = serverPlayer.getSpawnPointPosition();
 
@@ -86,26 +87,11 @@ public class SpawnPointCompat implements PresetModule {
 		}
 	}
 
-	@Override
-	public Identifier getId() {
-		return ID;
-	}
-
-	@Override
-	public MutableText getDisableConfirmation() {
-		return Text.translatable("commands.switchy_teleport.module.warn.spawn_point");
-	}
-
-	@Override
-	public boolean isDefault() {
-		return isDefault;
-	}
-
 	public static void touch() {
 	}
 
 	// Runs on touch() - but only once.
 	static {
-		PresetModuleRegistry.registerModule(ID, SpawnPointCompat::new);
+		PresetModuleRegistry.registerModule(ID, SpawnPointCompat::new, false, ModuleImportable.OPERATOR, Set.of(), Text.translatable("commands.switchy_teleport.module.warn.spawn_point"));
 	}
 }

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -23,7 +23,7 @@
 		"depends": [
 			{
 				"id": "switchy",
-				"versions": ">=1.3.0"
+				"versions": ">=1.8.0"
 			},
 			{
 				"id": "quilt_loader",


### PR DESCRIPTION
In Switchy 1.8, we made some breaking changes to the module format to clean up the code and support modules that aren't created until right before the first player joins the game.

Namely - module settings like default and disableConfirmation are now set and final on register.

As a note - there's actually a pre-existing incompatibility with 1.18 #2 in the mod - the use of `Text.translatable()` crashes the game - but it was hard to notice because you previously had to disable the module *on* 1.18 to see this happen - now it happens on startup.

I'd recommend either splitting your versions, or just using the generic warning message instead.