### PR TITLE
Don't use enhanced lang to support switchy 2.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx2G
 org.gradle.parallel = true
 
 # Mod Properties
-version = 1.2.0
+version = 1.2.1
 maven_group = xyz.fulmine
 archives_base_name = switchy-teleport
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ minecraft = "1.19.2"
 quilt_mappings = "1.19.2+build.19"
 quilt_loader = "0.17.4"
 
-switchy = "2.0.0-beta.13+1.19"
+switchy = "2.1.1+1.19"
 
 quilted_fabric_api = "4.0.0-beta.14+0.62.0-1.19.2"
 

--- a/src/main/resources/assets/switchy_teleport/lang/en_us.json
+++ b/src/main/resources/assets/switchy_teleport/lang/en_us.json
@@ -1,15 +1,4 @@
 {
-  "lib39:enable_enhanced_lang": true,
-  "switchy": {
-    "teleport": {
-      "module": {
-        "last_location": {
-          "tooltip": "Currently at {} X:{} Y:{} Z:{}"
-        },
-        "spawn_point": {
-          "tooltip": "Spawns at {} X:{} Y:{} Z:{}"
-        }
-      }
-    }
-  }
+  "switchy.teleport.module.last_location.tooltip": "Currently at {} X:{} Y:{} Z:{}",
+  "switchy.teleport.module.spawn_point.tooltip": "Spawns at {} X:{} Y:{} Z:{}"
 }

--- a/src/main/resources/data/switchy_teleport/lang/en_us.json
+++ b/src/main/resources/data/switchy_teleport/lang/en_us.json
@@ -1,21 +1,10 @@
 {
-  "lib39:enable_enhanced_lang": true,
-  "switchy": {
-    "teleport": {
-      "module": {
-        "last_location": {
-          "description": "A module that switches the location of the player.",
-          "enabled": "You will have a separate tracked location for each preset.",
-          "disabled": "Your location wont be tracked per-preset; you will not be teleported when switching.",
-          "warning": "All saved locations will be IMMEDIATELY lost. This is irreversible."
-        },
-        "spawn_point": {
-          "description": "A module that switches the spawn point of the player.",
-          "enabled": "You will have separate spawn points per-preset.",
-          "disabled": "You will share a single spawn point across all presets.",
-          "warning": "All other spawn points will be IMMEDIATELY lost. This is irreversible."
-        }
-      }
-    }
-  }
+  "switchy.teleport.module.last_location.description": "A module that switches the location of the player.",
+  "switchy.teleport.module.last_location.enabled": "You will have a separate tracked location for each preset.",
+  "switchy.teleport.module.last_location.disabled": "Your location wont be tracked per-preset; you will not be teleported when switching.",
+  "switchy.teleport.module.last_location.warning": "All saved locations will be IMMEDIATELY lost. This is irreversible.",
+  "switchy.teleport.module.spawn_point.description": "A module that switches the spawn point of the player.",
+  "switchy.teleport.module.spawn_point.enabled": "You will have separate spawn points per-preset.",
+  "switchy.teleport.module.spawn_point.disabled": "You will share a single spawn point across all presets.",
+  "switchy.teleport.module.spawn_point.warning": "All other spawn points will be IMMEDIATELY lost. This is irreversible."
 }

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -30,7 +30,7 @@
 		"depends": [
 			{
 				"id": "switchy-core",
-				"versions": ">=2.0.0-"
+				"versions": ">=2.1.1"
 			},
 			{
 				"id": "quilt_loader",


### PR DESCRIPTION
Hello! One of the other times we made a PR, we swapped the lang files to use lib39 dessicant's *enhanced  lang* feature, like switchy does.

We've stopped bundling lib39 in 2.1.1 because we were using it for... *only* this. So, here you go!